### PR TITLE
[WIP] Edge case when reading past end of stream

### DIFF
--- a/src/Cedar.EventStore.AcceptanceTests/EventStoreAcceptanceTests.ReadStream.cs
+++ b/src/Cedar.EventStore.AcceptanceTests/EventStoreAcceptanceTests.ReadStream.cs
@@ -166,7 +166,26 @@
             }
         }
 
-        // ReSharper disable once UnusedMethodReturnValue.Global
+        [Fact]
+        public async Task When_read_existing_stream_forwards_past_the_end_should_get_empty_page()
+        {
+            using(var fixture = GetFixture())
+            {
+                using(var eventStore = await fixture.GetEventStore())
+                {
+                    await eventStore.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamEvents(1));
+
+                    var streamEventsPage = await eventStore.ReadStreamForwards("stream-1", 1, int.MaxValue);
+
+                    streamEventsPage.Status.ShouldBe(PageReadStatus.Success);
+                    streamEventsPage.Events.Any().ShouldBe(false);
+                    streamEventsPage.IsEndOfStream.ShouldBe(true);
+                    streamEventsPage.LastStreamVersion.ShouldBe(0);
+                    streamEventsPage.NextStreamVersion.ShouldBe(1);
+                }
+            }
+        }
+        // ReSharper disable MemberCanBePrivate.Global
         public static IEnumerable<object[]> GetReadStreamForwardsTheories()
         {
             var theories = new[]
@@ -206,6 +225,7 @@
 
             return theories.Select(t => new object[] { t });
         }
+        // ReSharper restore MemberCanBePrivate.Global
 
         public class ReadStreamTheory
         {

--- a/src/Cedar.EventStore/InMemory/InMemoryEventStore.cs
+++ b/src/Cedar.EventStore/InMemory/InMemoryEventStore.cs
@@ -358,7 +358,7 @@ namespace Cedar.EventStore
                 }
 
                 var lastStreamVersion = stream.Events.Last().StreamVersion;
-                var nextStreamVersion = events.Last().StreamVersion + 1;
+                var nextStreamVersion = (events.LastOrDefault()?.StreamVersion ?? lastStreamVersion) + 1;
                 var endOfStream = i == stream.Events.Count;
 
                 var page = new StreamEventsPage(


### PR DESCRIPTION
Stream has one event in it. I `ReadStreamForwards(streamName, 0, 1, ct)`. Apply the first event to my aggregate. Then, I want to read the rest of the stream. `ReadStreamForwards(streamName, 1, int32.MaxValue, ct)`. I get sequence contains no elements. I feel that I should get an empty page here.

