### PR TITLE
If a gap is detected in the allstream page sequence number, reissue query

### DIFF
--- a/src/SqlStreamStore/Infrastructure/TaskExtensions.cs
+++ b/src/SqlStreamStore/Infrastructure/TaskExtensions.cs
@@ -5,19 +5,20 @@
 
     public static class TaskExtensions
     {
+        /// <summary>
+        /// ConfigureAwait(false)
+        /// </summary>
         public static ConfiguredTaskAwaitable NotOnCapturedContext(this Task task)
         {
             return task.ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// ConfigureAwait(false)
+        /// </summary>
         public static ConfiguredTaskAwaitable<T> NotOnCapturedContext<T>(this Task<T> task)
         {
             return task.ConfigureAwait(false);
-        }
-
-        public static void SwallowException(this Task task)
-        {
-            task.ContinueWith(_ => { });
         }
     }
 }


### PR DESCRIPTION
Fixes #31  Under heavy load, a read may "miss" messages because of position values being reserved but not persisted. Here we check the last page and if there is a missing position, re-issue the query after a short delay. I'm expecting this to be an extreme edgecase. I have not yet managed to make this occur, but it's theoretically possible.

Here we check for a gap / missing position and reissue the query after a delay. Haven't figured out how to test this yet... but opening PR for feedback.




