### PR TITLE
Unify Initialization API Across Stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+src/.idea/

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.cs
@@ -56,7 +56,7 @@
             _appendToStreamSqlMetadata = sqlMetaData.ToArray();
         }
 
-        public async Task InitializeStore(
+        public override async Task InitializeStore(
             bool ignoreErrors = false,
             CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/src/SqlStreamStore/IStreamStore.cs
+++ b/src/SqlStreamStore/IStreamStore.cs
@@ -117,5 +117,15 @@
             int? maxCount = null,
             string metadataJson = null,
             CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Initializes the underlying storage mechanism.
+        /// </summary>
+        /// <param name="ignoreErrors">Ignore any errors that occur on initialization.</param>
+        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <returns></returns>
+        Task InitializeStore(
+            bool ignoreErrors = false,
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -55,6 +55,11 @@ namespace SqlStreamStore
             }
         }
 
+        public override Task InitializeStore(
+                bool ignoreErrors = false,
+                CancellationToken cancellationToken = default(CancellationToken))
+            => Task.FromResult(0);
+
         public override Task<int> GetmessageCount(string streamId, CancellationToken cancellationToken = new CancellationToken())
         {
             using(_lock.UseReadLock())

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -55,11 +55,6 @@ namespace SqlStreamStore
             }
         }
 
-        public override Task InitializeStore(
-                bool ignoreErrors = false,
-                CancellationToken cancellationToken = default(CancellationToken))
-            => Task.FromResult(0);
-
         public override Task<int> GetmessageCount(string streamId, CancellationToken cancellationToken = new CancellationToken())
         {
             using(_lock.UseReadLock())

--- a/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
@@ -164,5 +164,9 @@ namespace SqlStreamStore.Infrastructure
             }
             base.Dispose(disposing);
         }
+
+        public abstract async Task InitializeStore(
+            bool ignoreErrors = false,
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
@@ -165,8 +165,8 @@ namespace SqlStreamStore.Infrastructure
             base.Dispose(disposing);
         }
 
-        public abstract Task InitializeStore(
+        public virtual Task InitializeStore(
             bool ignoreErrors = false,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default(CancellationToken)) => Task.FromResult(0);
     }
 }

--- a/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/StreamStoreBase.cs
@@ -165,7 +165,7 @@ namespace SqlStreamStore.Infrastructure
             base.Dispose(disposing);
         }
 
-        public abstract async Task InitializeStore(
+        public abstract Task InitializeStore(
             bool ignoreErrors = false,
             CancellationToken cancellationToken = default(CancellationToken));
     }


### PR DESCRIPTION
I'm trying to avoid writing code that looks like this:

```
if (usingMsSql) {
	var store = new MsSqlStreamStore(...);

	startupActions.Add(ct => store.InitializeStore(false, ct))

	_store = _store;
} else if (usingAurora) {
	var store = new MySqlStreamStore(...);

	startupActions.Add(ct => store.InitializeStore(false, ct))

	_store = _store;
} else {
	_store = new InMemoryStreamStore();
}
```

Without this, encapsulation becomes extremely difficult.