### PR TITLE
Subscriptions: Extends callback delegates to include the Subscription instance.

### DIFF
--- a/src/Example/SubscriptToAllExample.cs
+++ b/src/Example/SubscriptToAllExample.cs
@@ -39,7 +39,7 @@ namespace Example
             }
         }
 
-        private Task StreamMessageReceived(StreamMessage streamMessage)
+        private Task StreamMessageReceived(IAllStreamSubscription _, StreamMessage streamMessage)
         {
             Console.WriteLine(streamMessage.StreamId);
             _currentPosition = streamMessage.Position;

--- a/src/Example/SubscriptToAllExample.cs
+++ b/src/Example/SubscriptToAllExample.cs
@@ -27,7 +27,7 @@ namespace Example
             CaughtUp = isCaughtUp;
         }
 
-        private void SubscriptionDropped(SubscriptionDroppedReason reason, Exception exception)
+        private void SubscriptionDropped(IAllStreamSubscription _, SubscriptionDroppedReason reason, Exception exception)
         {
             if(reason == SubscriptionDroppedReason.StreamStoreError)
             {

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -2,5 +2,5 @@
 
 [assembly: AssemblyProduct("SqlStreamStore")]
 [assembly: AssemblyCopyright("Copyright Damian Hickey & Contributors 2015 - 2016")]
-[assembly: AssemblyVersion("0.4.3.0")]
-[assembly: AssemblyFileVersion("0.4.3.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
@@ -30,7 +30,7 @@
                     using (var subscription = store.SubscribeToStream(
                         streamId1,
                         null,
-                        message =>
+                        (_, message) =>
                         {
                             receivedMessages.Add(message);
                             if (message.StreamVersion == 11)
@@ -68,7 +68,7 @@
                     using (var subscription = store.SubscribeToStream(
                         streamId,
                         null,
-                        message =>
+                        (_, message) =>
                         {
                             receivedMessages.Add(message);
                             if (message.StreamVersion == 1)
@@ -109,7 +109,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using(store.SubscribeToAll(
                         null,
-                        message =>
+                        (_, message) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} " +
                                                         $"{message.StreamVersion} {message.Position}");
@@ -146,7 +146,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using (store.SubscribeToAll(
                         null,
-                        message =>
+                        (_, message) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} {message.StreamVersion} {message.Position}");
                             receivedMessages.Add(message);
@@ -189,7 +189,7 @@
                     using (var subscription = store.SubscribeToStream(
                         streamId1,
                         StreamVersion.End,
-                        message =>
+                        (_, message) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} {message.StreamVersion} "
                                                         + $"{message.Position}");
@@ -239,7 +239,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using(var subscription = store.SubscribeToAll(
                         Position.End,
-                        message =>
+                        (_, message) =>
                         {
                             _testOutputHelper.WriteLine($"StreamId={message.StreamId} Version={message.StreamVersion} "
                                                         + $"Position={message.Position}");
@@ -275,7 +275,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using (var subscription = store.SubscribeToAll(
                         Position.End,
-                        message =>
+                        (_, message) =>
                         {
                             receivedMessages.Add(message);
                             if (message.StreamId == streamId1 && message.StreamVersion == 9)
@@ -315,7 +315,7 @@
                     using (var subscription = store.SubscribeToStream(
                         streamId1,
                         7,
-                        message =>
+                        (_, message) =>
                         {
                             receivedCount++;
                             if (message.StreamVersion == 11)
@@ -358,7 +358,7 @@
                     var subscriptions = Enumerable.Range(0, subscriptionCount)
                         .Select(index => store.SubscribeToAll(
                             null,
-                            streamMessageReceived: message =>
+                            (_, message) =>
                             {
                                 if(message.StreamVersion == 1)
                                 {
@@ -402,7 +402,7 @@
                         .Select(index => store.SubscribeToStream(
                             streamId1,
                             0,
-                            streamMessageReceived: message =>
+                            (_, message) =>
                             {
                                 if(message.StreamVersion == 1)
                                 {
@@ -441,7 +441,7 @@
                     List<StreamMessage> receivedMessages = new List<StreamMessage>();
                     using (store.SubscribeToAll(
                         null,
-                        message =>
+                        (_, message) =>
                         {
                             _testOutputHelper.WriteLine($"Received message {message.StreamId} " +
                                                         $"{message.StreamVersion} {message.Position}");
@@ -475,7 +475,7 @@
                 using(var store = await fixture.GetStreamStore())
                 {
                     var eventReceivedException = new TaskCompletionSource<SubscriptionDroppedReason>();
-                    StreamMessageReceived messageReceived = _ =>
+                    StreamMessageReceived messageReceived = (_, __) =>
                     {
                         throw new Exception();
                     };
@@ -511,7 +511,7 @@
                     var tcs = new TaskCompletionSource<SubscriptionDroppedReason>();
                     var subscription = store.SubscribeToStream("stream-1",
                         StreamVersion.End,
-                        _ => Task.CompletedTask,
+                        (_, __) => Task.CompletedTask,
                         (reason, exception) =>
                         {
                             tcs.SetResult(reason);
@@ -536,7 +536,7 @@
                     var handler = new AsyncAutoResetEvent();
                     var subscription = store.SubscribeToStream(streamId,
                         StreamVersion.Start,
-                        async _ =>
+                        async (_, __) =>
                         {
                             handler.Set();
                             await handler.WaitAsync(); // block "handling" while a dispose occurs
@@ -568,7 +568,7 @@
                     string streamId = "stream-1";
                     var subscription = store.SubscribeToStream(streamId,
                         StreamVersion.Start,
-                        _ => Task.CompletedTask);
+                        (_, __) => Task.CompletedTask);
                     await AppendMessages(store, streamId, 2);
                     subscription.Dispose();
                     subscription.Dispose();
@@ -584,7 +584,7 @@
                 using (var store = await fixture.GetStreamStore())
                 {
                     var eventReceivedException = new TaskCompletionSource<SubscriptionDroppedReason>();
-                    StreamMessageReceived messageReceived = _ =>
+                    AllStreamMessageReceived messageReceived = (_, __) =>
                     {
                         throw new Exception();
                     };
@@ -620,7 +620,7 @@
                     var tcs = new TaskCompletionSource<SubscriptionDroppedReason>();
                     var subscription = store.SubscribeToAll(
                         Position.End,
-                        _ => Task.CompletedTask,
+                        (_, __) => Task.CompletedTask,
                         (reason, exception) =>
                         {
                             tcs.SetResult(reason);
@@ -645,7 +645,7 @@
                     var handler = new AsyncAutoResetEvent();
                     var subscription = store.SubscribeToAll(
                         Position.End,
-                        async _ =>
+                        async (_, __) =>
                         {
                             handler.Set();
                             await handler.WaitAsync().WithTimeout(); // block "handling" while a dispose occurs
@@ -678,7 +678,7 @@
                     string streamId = "stream-1";
                     var subscription = store.SubscribeToAll(
                         Position.Start,
-                        _ => Task.CompletedTask);
+                        (_, __) => Task.CompletedTask);
                     await AppendMessages(store, streamId, 2);
                     subscription.Dispose();
                     subscription.Dispose();
@@ -698,7 +698,7 @@
                     var caughtUp = new TaskCompletionSource<bool>();
                     var subscription = store.SubscribeToAll(
                         null,
-                        _ => Task.CompletedTask,
+                        (_, __) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
                             if(b)
@@ -726,7 +726,7 @@
                     var subscription = store.SubscribeToStream(
                         streamId,
                         null,
-                        _ => Task.CompletedTask,
+                        (_, __) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
                             if (b)
@@ -755,7 +755,7 @@
 
                     var subscription = store.SubscribeToAll(
                         null,
-                        _ => Task.CompletedTask,
+                        (_, __) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
                             if (b)
@@ -790,7 +790,7 @@
                     var subscription = store.SubscribeToStream(
                         streamId,
                         null,
-                        _ => Task.CompletedTask,
+                        (_, __) => Task.CompletedTask,
                         hasCaughtUp: b =>
                         {
                             if (b)

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
@@ -55,6 +55,34 @@
         }
 
         [Fact]
+        public async Task When_subscribe_to_a_stream_and_receive_message_then_should_get_subscription_instance()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await AppendMessages(store, streamId, 10);
+
+                    var done = new TaskCompletionSource<IStreamSubscription>();
+                    using (var subscription = store.SubscribeToStream(
+                        streamId,
+                        null,
+                        (sub, _) =>
+                        {
+                            done.SetResult(sub);
+                            return Task.CompletedTask;
+                        }))
+                    {
+                        var receivedSubscription = await done.Task.WithTimeout();
+
+                        receivedSubscription.ShouldBe(subscription);
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public async Task Can_subscribe_to_a_stream_from_start_before_messages_are_written()
         {
             using (var fixture = GetFixture())
@@ -126,6 +154,33 @@
                         await receiveMessages.Task.WithTimeout();
 
                         receivedMessages.Count.ShouldBe(7);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task When_subscribe_to_all_and_receive_message_then_should_get_subscription_instance()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await AppendMessages(store, streamId, 10);
+
+                    var done = new TaskCompletionSource<IAllStreamSubscription>();
+                    using (var subscription = store.SubscribeToAll(
+                        null,
+                        (sub, _) =>
+                        {
+                            done.SetResult(sub);
+                            return Task.CompletedTask;
+                        }))
+                    {
+                        var receivedSubscription = await done.Task.WithTimeout();
+
+                        receivedSubscription.ShouldBe(subscription);
                     }
                 }
             }

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.Subscriptions.cs
@@ -534,7 +534,7 @@
                     {
                         throw new Exception();
                     };
-                    SubscriptionDropped subscriptionDropped = (reason, exception) =>
+                    SubscriptionDropped subscriptionDropped = (_, reason, __) =>
                     {
                         eventReceivedException.SetResult(reason);
                     };
@@ -567,7 +567,7 @@
                     var subscription = store.SubscribeToStream("stream-1",
                         StreamVersion.End,
                         (_, __) => Task.CompletedTask,
-                        (reason, exception) =>
+                        (_, reason, __) =>
                         {
                             tcs.SetResult(reason);
                         });
@@ -575,6 +575,31 @@
                     var droppedReason = await tcs.Task.WithTimeout();
 
                     droppedReason.ShouldBe(SubscriptionDroppedReason.Disposed);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task When_stream_subscription_dropped_then_should_supply_subscription_instance()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    var tcs = new TaskCompletionSource<IStreamSubscription>();
+                    var subscription = store.SubscribeToStream(
+                        "stream-1",
+                        null,
+                        (_, __) => Task.CompletedTask,
+                        (sub, _, __) =>
+                        {
+                            tcs.SetResult(sub);
+                        });
+
+                    subscription.Dispose();
+                    var receivedSubscriptiuon = await tcs.Task.WithTimeout();
+
+                    receivedSubscriptiuon.ShouldBe(subscription);
                 }
             }
         }
@@ -596,7 +621,7 @@
                             handler.Set();
                             await handler.WaitAsync(); // block "handling" while a dispose occurs
                         },
-                        (reason, exception) =>
+                        (_, reason, __) =>
                         {
                             droppedTcs.SetResult(reason);
                         });
@@ -643,7 +668,7 @@
                     {
                         throw new Exception();
                     };
-                    SubscriptionDropped subscriptionDropped = (reason, exception) =>
+                    AllSubscriptionDropped subscriptionDropped = (_, reason, __) =>
                     {
                         eventReceivedException.SetResult(reason);
                     };
@@ -676,7 +701,7 @@
                     var subscription = store.SubscribeToAll(
                         Position.End,
                         (_, __) => Task.CompletedTask,
-                        (reason, exception) =>
+                        (_, reason, __) =>
                         {
                             tcs.SetResult(reason);
                         });
@@ -684,6 +709,29 @@
                     var droppedReason = await tcs.Task.WithTimeout();
 
                     droppedReason.ShouldBe(SubscriptionDroppedReason.Disposed);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task When_all_stream_subscription_dropped_then_should_supply_subscription_instance()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    var tcs = new TaskCompletionSource<IAllStreamSubscription>();
+                    var subscription = store.SubscribeToAll(
+                        Position.End,
+                        (_, __) => Task.CompletedTask,
+                        (sub, _, __) =>
+                        {
+                            tcs.SetResult(sub);
+                        });
+                    subscription.Dispose();
+                    var receivedSubscriptiuon = await tcs.Task.WithTimeout();
+
+                    receivedSubscriptiuon.ShouldBe(subscription);
                 }
             }
         }
@@ -705,7 +753,7 @@
                             handler.Set();
                             await handler.WaitAsync().WithTimeout(); // block "handling" while a dispose occurs
                         },
-                        (reason, exception) =>
+                        (_, reason, __) =>
                         {
                             droppedTcs.SetResult(reason);
                         });

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.Subscriptions.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.Subscriptions.cs
@@ -26,7 +26,7 @@ namespace SqlStreamStore
         protected override IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
             AllStreamMessageReceived streamMessageReceived,
-            SubscriptionDropped subscriptionDropped,
+            AllSubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name)
         {

--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.Subscriptions.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.Subscriptions.cs
@@ -25,7 +25,7 @@ namespace SqlStreamStore
 
         protected override IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
-            StreamMessageReceived streamMessageReceived,
+            AllStreamMessageReceived streamMessageReceived,
             SubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name)

--- a/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreFixture.cs
+++ b/src/SqlStreamStore.Postgres.Tests/PostgresStreamStoreFixture.cs
@@ -1,9 +1,7 @@
 namespace SqlStreamStore
 {
     using System;
-    using System.Data.SqlClient;
     using System.Threading.Tasks;
-
     using SqlStreamStore.Postgres;
 
     public class PostgresStreamStoreFixture : StreamStoreAcceptanceTestFixture

--- a/src/SqlStreamStore.Postgres.Tests/Properties/AssemblyInfo.cs
+++ b/src/SqlStreamStore.Postgres.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
+++ b/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{55054819-94FE-4E33-9E2A-AA8CCE12D333}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SqlStreamStore.Postgres.Tests</RootNamespace>
+    <RootNamespace>SqlStreamStore</RootNamespace>
     <AssemblyName>SqlStreamStore.Postgres.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -143,6 +143,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.v2.ncrunchproject
+++ b/src/SqlStreamStore.Postgres.Tests/SqlStreamStore.Postgres.Tests.v2.ncrunchproject
@@ -18,10 +18,13 @@
   <DetectStackOverflow>true</DetectStackOverflow>
   <IncludeStaticReferencesInWorkspace>true</IncludeStaticReferencesInWorkspace>
   <DefaultTestTimeout>60000</DefaultTestTimeout>
-  <UseBuildConfiguration />
-  <UseBuildPlatform />
-  <ProxyProcessPath />
+  <UseBuildConfiguration></UseBuildConfiguration>
+  <UseBuildPlatform></UseBuildPlatform>
+  <ProxyProcessPath></ProxyProcessPath>
   <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
   <MSTestThreadApartmentState>STA</MSTestThreadApartmentState>
   <BuildProcessArchitecture>x86</BuildProcessArchitecture>
+  <IgnoredTests>
+    <AllTestsSelector />
+  </IgnoredTests>
 </ProjectConfiguration>

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-
     using SqlStreamStore.Infrastructure;
     using SqlStreamStore.Streams;
     using SqlStreamStore.Subscriptions;
@@ -74,7 +73,7 @@
 
         protected override IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
-            StreamMessageReceived streamMessageReceived,
+            AllStreamMessageReceived streamMessageReceived,
             SubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name)

--- a/src/SqlStreamStore.Postgres/PostgresStreamStore.cs
+++ b/src/SqlStreamStore.Postgres/PostgresStreamStore.cs
@@ -74,7 +74,7 @@
         protected override IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
             AllStreamMessageReceived streamMessageReceived,
-            SubscriptionDropped subscriptionDropped,
+            AllSubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name)
         {

--- a/src/SqlStreamStore.Postgres/Properties/AssemblyInfo.cs
+++ b/src/SqlStreamStore.Postgres/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/SqlStreamStore/App_Packages/LibLog.4.2/LibLog.cs
+++ b/src/SqlStreamStore/App_Packages/LibLog.4.2/LibLog.cs
@@ -730,7 +730,6 @@ namespace SqlStreamStore.Logging.LogProviders
     using System.Linq.Expressions;
     using System.Reflection;
 #if !LIBLOG_PORTABLE
-    using System.Text;
 #endif
     using System.Text.RegularExpressions;
 

--- a/src/SqlStreamStore/IReadonlyStreamStore.cs
+++ b/src/SqlStreamStore/IReadonlyStreamStore.cs
@@ -155,7 +155,7 @@
         /// </returns>
         IAllStreamSubscription SubscribeToAll(
             long? continueAfterPosition,
-            StreamMessageReceived streamMessageReceived,
+            AllStreamMessageReceived streamMessageReceived,
             SubscriptionDropped subscriptionDropped = null,
             HasCaughtUp hasCaughtUp = null,
             string name = null);

--- a/src/SqlStreamStore/IReadonlyStreamStore.cs
+++ b/src/SqlStreamStore/IReadonlyStreamStore.cs
@@ -83,7 +83,7 @@
         ///     the end.
         /// </param>
         /// <param name="maxCount">T he maximum number of messages to read (int.MaxValue is a bad idea).</param>
-        /// <param name="cancellationToken"> The cancellation instruction. </param>
+        /// <param name="cancellationToken"> The cancellation instruction.</param>
         /// <returns>
         ///     An <see cref="ReadStreamPage"/> represent the result of the operation. If all the messages read
         ///     have expired then the message collection MAY be empty.
@@ -140,7 +140,7 @@
         ///     is terminated.
         /// </param>
         /// <param name="subscriptionDropped">
-        ///     A delegate that is invoked when a the subscription fails.
+        ///     A delegate that is invoked when a the subscription is dropped.
         /// </param>
         /// <param name="name">
         ///     The name of the subscription used for logging. Optional.
@@ -156,7 +156,7 @@
         IAllStreamSubscription SubscribeToAll(
             long? continueAfterPosition,
             AllStreamMessageReceived streamMessageReceived,
-            SubscriptionDropped subscriptionDropped = null,
+            AllSubscriptionDropped subscriptionDropped = null,
             HasCaughtUp hasCaughtUp = null,
             string name = null);
 

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -594,7 +594,7 @@ namespace SqlStreamStore
 
         protected override IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
-            StreamMessageReceived streamMessageReceived,
+            AllStreamMessageReceived streamMessageReceived,
             SubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name)

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -595,7 +595,7 @@ namespace SqlStreamStore
         protected override IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
             AllStreamMessageReceived streamMessageReceived,
-            SubscriptionDropped subscriptionDropped,
+            AllSubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name)
         {

--- a/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
@@ -176,7 +176,7 @@ namespace SqlStreamStore.Infrastructure
         public IAllStreamSubscription SubscribeToAll(
             long? continueAfterPosition,
             AllStreamMessageReceived streamMessageReceived,
-            SubscriptionDropped subscriptionDropped = null,
+            AllSubscriptionDropped subscriptionDropped = null,
             HasCaughtUp hasCaughtUp = null,
             string name = null)
         {
@@ -258,7 +258,7 @@ namespace SqlStreamStore.Infrastructure
         protected abstract IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
             AllStreamMessageReceived streamMessageReceived,
-            SubscriptionDropped subscriptionDropped,
+            AllSubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name);
 

--- a/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
@@ -175,7 +175,7 @@ namespace SqlStreamStore.Infrastructure
 
         public IAllStreamSubscription SubscribeToAll(
             long? continueAfterPosition,
-            StreamMessageReceived streamMessageReceived,
+            AllStreamMessageReceived streamMessageReceived,
             SubscriptionDropped subscriptionDropped = null,
             HasCaughtUp hasCaughtUp = null,
             string name = null)
@@ -257,7 +257,7 @@ namespace SqlStreamStore.Infrastructure
 
         protected abstract IAllStreamSubscription SubscribeToAllInternal(
             long? fromPosition,
-            StreamMessageReceived streamMessageReceived,
+            AllStreamMessageReceived streamMessageReceived,
             SubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name);

--- a/src/SqlStreamStore/SqlStreamStore.csproj
+++ b/src/SqlStreamStore/SqlStreamStore.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Streams\Deleted.cs" />
     <Compile Include="Streams\ErrorMessages.cs" />
     <Compile Include="Subscriptions\AllStreamMessageReceived.cs" />
+    <Compile Include="Subscriptions\AllSubscriptionDropped.cs" />
     <Compile Include="Subscriptions\CreateStreamStoreNotifier.cs" />
     <Compile Include="Subscriptions\HasCaughtUp.cs" />
     <Compile Include="Subscriptions\IStreamStoreNotifier.cs" />

--- a/src/SqlStreamStore/SqlStreamStore.csproj
+++ b/src/SqlStreamStore/SqlStreamStore.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Streams\ReadAllPage.cs" />
     <Compile Include="Streams\Deleted.cs" />
     <Compile Include="Streams\ErrorMessages.cs" />
+    <Compile Include="Subscriptions\AllStreamMessageReceived.cs" />
     <Compile Include="Subscriptions\CreateStreamStoreNotifier.cs" />
     <Compile Include="Subscriptions\HasCaughtUp.cs" />
     <Compile Include="Subscriptions\IStreamStoreNotifier.cs" />

--- a/src/SqlStreamStore/Subscriptions/AllStreamMessageReceived.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamMessageReceived.cs
@@ -4,14 +4,13 @@
     using SqlStreamStore.Streams;
 
     /// <summary>
-    ///       Repesents a delegate that is invoked when a stream messages has been received in a subscription.
+    ///      Repesents a delegate that is invoked when a stream messages has been received in a subscription.
     /// </summary>
     /// <param name="subscription">
     ///      The source subscription.
     /// </param>
     /// <param name="streamMessage">
-    ///     The stream message.
-    /// </param>
+    ///     The stream message.</param>
     /// <returns>A task that represents the asynchronous handling of the stream message.</returns>
-    public delegate Task StreamMessageReceived(IStreamSubscription subscription, StreamMessage streamMessage);
+    public delegate Task AllStreamMessageReceived(IAllStreamSubscription subscription, StreamMessage streamMessage);
 }

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -18,7 +18,7 @@
         private readonly IReadonlyStreamStore _readonlyStreamStore;
         private readonly AllStreamMessageReceived _streamMessageReceived;
         private readonly HasCaughtUp _hasCaughtUp;
-        private readonly SubscriptionDropped _subscriptionDropped;
+        private readonly AllSubscriptionDropped _subscriptionDropped;
         private readonly IDisposable _notification;
         private readonly CancellationTokenSource _disposed = new CancellationTokenSource();
         private readonly AsyncAutoResetEvent _streamStoreNotification = new AsyncAutoResetEvent();
@@ -30,7 +30,7 @@
             IReadonlyStreamStore readonlyStreamStore,
             IObservable<Unit> streamStoreAppendedNotification,
             AllStreamMessageReceived streamMessageReceived,
-            SubscriptionDropped subscriptionDropped,
+            AllSubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name)
         {
@@ -39,7 +39,7 @@
             _nextPosition = continueAfterPosition + 1 ?? Position.Start;
             _readonlyStreamStore = readonlyStreamStore;
             _streamMessageReceived = streamMessageReceived;
-            _subscriptionDropped = subscriptionDropped ?? ((_, __) => { });
+            _subscriptionDropped = subscriptionDropped ?? ((_, __, ___) => { });
             _hasCaughtUp = hasCaughtUp ?? (_ => { }); 
             Name = string.IsNullOrWhiteSpace(name) ? Guid.NewGuid().ToString() : name;
 
@@ -206,7 +206,7 @@
             try
             {
                 s_logger.InfoException($"All stream subscription dropped {Name}. Reason: {reason}", exception);
-                _subscriptionDropped.Invoke(reason, exception);
+                _subscriptionDropped.Invoke(this, reason, exception);
             }
             catch (Exception ex)
             {

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -16,7 +16,7 @@
         private int _pageSize = DefaultPageSize;
         private long _nextPosition;
         private readonly IReadonlyStreamStore _readonlyStreamStore;
-        private readonly StreamMessageReceived _streamMessageReceived;
+        private readonly AllStreamMessageReceived _streamMessageReceived;
         private readonly HasCaughtUp _hasCaughtUp;
         private readonly SubscriptionDropped _subscriptionDropped;
         private readonly IDisposable _notification;
@@ -29,7 +29,7 @@
             long? continueAfterPosition,
             IReadonlyStreamStore readonlyStreamStore,
             IObservable<Unit> streamStoreAppendedNotification,
-            StreamMessageReceived streamMessageReceived,
+            AllStreamMessageReceived streamMessageReceived,
             SubscriptionDropped subscriptionDropped,
             HasCaughtUp hasCaughtUp,
             string name)
@@ -183,7 +183,7 @@
                 LastPosition = message.Position;
                 try
                 {
-                    await _streamMessageReceived(message).NotOnCapturedContext();
+                    await _streamMessageReceived(this, message).NotOnCapturedContext();
                 }
                 catch (Exception ex)
                 {

--- a/src/SqlStreamStore/Subscriptions/AllSubscriptionDropped.cs
+++ b/src/SqlStreamStore/Subscriptions/AllSubscriptionDropped.cs
@@ -9,10 +9,9 @@
     ///     The source subscription.
     /// </param>
     /// <param name="reason">
-    ///     The subscription dropped reason.
-    /// </param>
+    ///     The subscription dropped reason.</param>
     /// <param name="exception">
     ///     The underlying exception that caused the subscription to drop, if one exists.
     /// </param>
-    public delegate void SubscriptionDropped(IStreamSubscription subscription, SubscriptionDroppedReason reason, Exception exception = null);
+    public delegate void AllSubscriptionDropped(IAllStreamSubscription subscription, SubscriptionDroppedReason reason, Exception exception = null);
 }

--- a/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
@@ -39,7 +39,7 @@
             _continueAfterVersion = continueAfterVersion;
             _readonlyStreamStore = readonlyStreamStore;
             _streamMessageReceived = streamMessageReceived;
-            _subscriptionDropped = subscriptionDropped ?? ((_, __) => { });
+            _subscriptionDropped = subscriptionDropped ?? ((_, __, ___) => { });
             _hasCaughtUp = hasCaughtUp ?? ((_) => { });
             Name = string.IsNullOrWhiteSpace(name) ? Guid.NewGuid().ToString() : name;
 
@@ -226,7 +226,7 @@
             try
             {
                 s_logger.InfoException($"Subscription dropped {Name}/{StreamId}. Reason: {reason}", exception);
-                _subscriptionDropped.Invoke(reason, exception);
+                _subscriptionDropped.Invoke(this, reason, exception);
             }
             catch(Exception ex)
             {

--- a/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
@@ -203,7 +203,7 @@
                 LastVersion = message.StreamVersion;
                 try
                 {
-                    await _streamMessageReceived(message).NotOnCapturedContext();
+                    await _streamMessageReceived(this, message).NotOnCapturedContext();
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Handling a `StreamMessageReceived` or a `SubscriptionDropped` callback will include a reference to the subscription instance.