### PR TITLE
Auto dispose subscriptions with stream store instance is disposed.

### DIFF
--- a/src/SqlStreamStore.Tests/Infrastructure/TaskQueueTests.cs
+++ b/src/SqlStreamStore.Tests/Infrastructure/TaskQueueTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Threading;
     using System.Threading.Tasks;
     using Shouldly;
     using Xunit;

--- a/src/SqlStreamStore/IReadonlyStreamStore.cs
+++ b/src/SqlStreamStore/IReadonlyStreamStore.cs
@@ -186,5 +186,7 @@
         Task<StreamMetadataResult> GetStreamMetadata(
             string streamId,
             CancellationToken cancellationToken = default(CancellationToken));
+
+        event Action OnDispose;
     }
 }

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -577,7 +577,7 @@ namespace SqlStreamStore
             HasCaughtUp hasCaughtUp,
             string name)
         {
-            IStreamSubscription subscription = new StreamSubscription(
+            return new StreamSubscription(
                 streamId,
                 startVersion,
                 this,
@@ -586,7 +586,6 @@ namespace SqlStreamStore
                 subscriptionDropped,
                 hasCaughtUp,
                 name);
-            return subscription;
         }
 
         protected override Task<long> ReadHeadPositionInternal(CancellationToken cancellationToken)

--- a/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
+++ b/src/SqlStreamStore/Infrastructure/ReadonlyStreamStoreBase.cs
@@ -214,10 +214,13 @@ namespace SqlStreamStore.Infrastructure
 
         public void Dispose()
         {
+            OnDispose?.Invoke();
             Dispose(true);
             GC.SuppressFinalize(this);
             _isDisposed = true;
         }
+
+        public event Action OnDispose;
 
         protected abstract Task<ReadAllPage> ReadAllForwardsInternal(
             long fromPositionExlusive,

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -43,6 +43,8 @@
             _hasCaughtUp = hasCaughtUp ?? (_ => { }); 
             Name = string.IsNullOrWhiteSpace(name) ? Guid.NewGuid().ToString() : name;
 
+            readonlyStreamStore.OnDispose += ReadonlyStreamStoreOnOnDispose;
+
             _notification = streamStoreAppendedNotification.Subscribe(_ =>
             {
                 _streamStoreNotification.Set();
@@ -76,6 +78,12 @@
             }
             _disposed.Cancel();
             _notification.Dispose();
+        }
+
+        private void ReadonlyStreamStoreOnOnDispose()
+        {
+            _readonlyStreamStore.OnDispose -= ReadonlyStreamStoreOnOnDispose;
+            Dispose();
         }
 
         private async Task PullAndPush()

--- a/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/AllStreamSubscription.cs
@@ -138,6 +138,11 @@
                     1,
                     _disposed.Token).NotOnCapturedContext();
             }
+            catch (ObjectDisposedException)
+            {
+                NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
+                throw;
+            }
             catch (OperationCanceledException)
             {
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
@@ -163,6 +168,11 @@
                 readAllPage = await _readonlyStreamStore
                     .ReadAllForwards(_nextPosition, MaxCountPerRead, _disposed.Token)
                     .NotOnCapturedContext();
+            }
+            catch(ObjectDisposedException)
+            {
+                NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
+                throw;
             }
             catch (OperationCanceledException)
             {

--- a/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
@@ -155,6 +155,11 @@
                     1,
                     _disposed.Token).NotOnCapturedContext();
             }
+            catch (ObjectDisposedException)
+            {
+                NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
+                throw;
+            }
             catch (OperationCanceledException)
             {
                 NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
@@ -184,6 +189,11 @@
                         MaxCountPerRead,
                         _disposed.Token)
                     .NotOnCapturedContext();
+            }
+            catch (ObjectDisposedException)
+            {
+                NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
+                throw;
             }
             catch (OperationCanceledException)
             {

--- a/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
+++ b/src/SqlStreamStore/Subscriptions/StreamSubscription.cs
@@ -43,6 +43,8 @@
             _hasCaughtUp = hasCaughtUp ?? ((_) => { });
             Name = string.IsNullOrWhiteSpace(name) ? Guid.NewGuid().ToString() : name;
 
+            readonlyStreamStore.OnDispose += ReadonlyStreamStoreOnOnDispose;
+
             _notification = streamStoreAppendedNotification.Subscribe(_ =>
             {
                 _streamStoreNotification.Set();
@@ -76,6 +78,13 @@
             }
             _disposed.Cancel();
             _notification.Dispose();
+            NotifySubscriptionDropped(SubscriptionDroppedReason.Disposed);
+        }
+
+        private void ReadonlyStreamStoreOnOnDispose()
+        {
+            _readonlyStreamStore.OnDispose -= ReadonlyStreamStoreOnOnDispose;
+            Dispose();
         }
 
         private async Task PullAndPush()


### PR DESCRIPTION
Add event `OnDispose` to `IReadOnlyStreamStore` that is raised when the store is disposing. `StreamSubscription` and `AllStreamSubscription` subscribe to this and dispose themselves when OnDispose is raised.

Fixes #48 