### PR TITLE
Retry on deadlock for all appends variations.

### DIFF
--- a/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
+++ b/src/SqlStreamStore.MsSql/MsSqlStreamStore.AppendStream.cs
@@ -68,20 +68,20 @@
             }
             if(expectedVersion == ExpectedVersion.NoStream)
             {
-                return await AppendToStreamExpectedVersionNoStream(
+                return await RetryOnDeadLock(() => AppendToStreamExpectedVersionNoStream(
                     connection,
                     transaction,
                     sqlStreamId,
                     messages,
-                    cancellationToken);
+                    cancellationToken));
             }
-            return await AppendToStreamExpectedVersion(
+            return await RetryOnDeadLock(() => AppendToStreamExpectedVersion(
                 connection,
                 transaction,
                 sqlStreamId,
                 expectedVersion,
                 messages,
-                cancellationToken);
+                cancellationToken));
         }
 
         private async Task<T> RetryOnDeadLock<T>(Func<Task<T>> operation, int maxRetries = 2)


### PR DESCRIPTION
Apparently it can happen regardless of the db isolation mode under load.