### PR TITLE
Append result verification

### DIFF
--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.AppendStream.cs
@@ -11,9 +11,9 @@
         public async Task When_append_stream_second_time_with_no_stream_expected_and_different_message_then_should_throw
             ()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -34,9 +34,9 @@
             ()
         {
             // Idempotency
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -52,12 +52,35 @@
 
         [Fact]
         public async Task
-            When_append_stream_second_time_with_no_stream_expected_and_additonal_messages_then_should_throw()
+            When_append_stream_second_time_with_no_stream_expected_and_same_messages_then_should_then_should_have_expected_result
+            ()
         {
             // Idempotency
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await store
+                        .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2));
+
+                    var result = await store
+                        .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2));
+
+                    result.CurrentVersion.ShouldBe(1);
+                    //result.NextExpectedVersion.ShouldBe(1);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task
+            When_append_stream_second_time_with_no_stream_expected_and_additional_messages_then_should_throw()
+        {
+            // Idempotency
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -77,9 +100,9 @@
             When_append_stream_second_time_with_no_stream_expected_and_same_inital_message_then_should_be_idempotent()
         {
             // Idempotency
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -95,11 +118,33 @@
 
         [Fact]
         public async Task
+            When_append_stream_second_time_with_no_stream_expected_and_same_inital_message_then_should_have_expected_result()
+        {
+            // Idempotency
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await store
+                        .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2));
+
+                    var result =
+                        await store.AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1));
+
+                    result.CurrentVersion.ShouldBe(1);
+                    //result.NextExpectedVersion.ShouldBe(0);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task
             When_append_stream_second_time_with_no_stream_expected_and_different_inital_messages_then_should_throw()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -117,9 +162,9 @@
         [Fact]
         public async Task When_append_with_wrong_expected_version_then_should_throw()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -137,9 +182,9 @@
         [Fact]
         public async Task Can_append_stream_with_correct_expected_version()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     var result = await store
@@ -157,9 +202,9 @@
         public async Task
             When_append_stream_with_correct_expected_version_second_time_with_same_messages_then_should_not_throw()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -176,12 +221,34 @@
 
         [Fact]
         public async Task
+    When_append_stream_with_correct_expected_version_second_time_with_same_messages_then_should_have_expected_result()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await store
+                        .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+                    await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5, 6));
+
+                    var result = await
+                            store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5, 6));
+
+                    result.CurrentVersion.ShouldBe(5);
+                    //result.NextExpectedVersion.ShouldBe(5);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task
             When_append_stream_with_correct_expected_version_second_time_with_same_initial_messages_then_should_not_throw
             ()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -198,11 +265,34 @@
 
         [Fact]
         public async Task
+    When_append_stream_with_correct_expected_version_second_time_with_same_initial_messages_then_should_have_expected_result
+    ()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+                    await store
+                        .AppendToStream(streamId, ExpectedVersion.NoStream, CreateNewStreamMessages(1, 2, 3));
+                    await store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5, 6));
+
+                    var result = await
+                            store.AppendToStream(streamId, 2, CreateNewStreamMessages(4, 5));
+
+                    result.CurrentVersion.ShouldBe(5);
+                    //result.NextExpectedVersion.ShouldBe(4);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task
             When_append_stream_with_correct_expected_version_second_time_with_additional_messages_then_should_throw()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -221,9 +311,9 @@
         [Fact]
         public async Task Can_append_to_non_existing_stream_with_expected_version_any()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     var result =
@@ -240,12 +330,12 @@
 
         [Fact]
         public async Task
-            When_append_stream_second_time_with_expected_version_any_and_all_messages_comitted_then_should_be_idempotent
+            When_append_stream_second_time_with_expected_version_any_and_all_messages_committed_then_should_be_idempotent
             ()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
 
@@ -264,12 +354,42 @@
 
         [Fact]
         public async Task
-            When_append_stream_with_expected_version_any_and_some_of_the_messages_previously_comitted_then_should_be_idempotent
+    When_append_stream_second_time_with_expected_version_any_and_all_messages_committed_then_should_have_expected_result
+    ()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+
+                    var result1 = await store
+                        .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
+
+                    result1.CurrentVersion.ShouldBe(2);
+                    //result1.NextExpectedVersion.ShouldBe(2);
+
+                    var result2 = await store
+                        .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
+
+                    result2.CurrentVersion.ShouldBe(2);
+                    //result2.NextExpectedVersion.ShouldBe(2);
+
+                    var page = await store
+                        .ReadStreamForwards(streamId, StreamVersion.Start, 10);
+                    page.Messages.Length.ShouldBe(3);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task
+            When_append_stream_with_expected_version_any_and_some_of_the_messages_previously_committed_then_should_be_idempotent
             ()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
 
@@ -286,12 +406,42 @@
             }
         }
 
+
         [Fact]
-        public async Task Can_append_stream_with_expected_version_any_and_none_of_then_messages_previously_comitted()
+        public async Task
+            When_append_stream_with_expected_version_any_and_some_of_the_messages_previously_committed_then_should_have_expected_result
+            ()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+
+                    var result1 = await store
+                        .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
+                    result1.CurrentVersion.ShouldBe(2);
+                    //result1.NextExpectedVersion.ShouldBe(2);
+
+                    var result2 = await store
+                        .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2));
+
+                    result2.CurrentVersion.ShouldBe(2);
+                    //result1.NextExpectedVersion.ShouldBe(1);
+
+                    var page = await store
+                        .ReadStreamForwards(streamId, StreamVersion.Start, 10);
+                    page.Messages.Length.ShouldBe(3);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Can_append_stream_with_expected_version_any_and_none_of_the_messages_previously_committed()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
 
@@ -309,13 +459,37 @@
         }
 
         [Fact]
+        public async Task Can_append_stream_with_expected_version_any_and_none_of_the_messages_previously_committed_should_have_expected_results()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    const string streamId = "stream-1";
+
+                    var result1 = await store
+                        .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(1, 2, 3));
+                    result1.CurrentVersion.ShouldBe(2);
+
+                    var result2 = await store
+                        .AppendToStream(streamId, ExpectedVersion.Any, CreateNewStreamMessages(4, 5, 6));
+                    result2.CurrentVersion.ShouldBe(5);
+
+                    var page = await store
+                        .ReadStreamForwards(streamId, StreamVersion.Start, 10);
+                    page.Messages.Length.ShouldBe(6);
+                }
+            }
+        }
+
+        [Fact]
         public async Task
-            When_append_stream_with_expected_version_any_and_some_of_the_messages_previously_comitted_and_with_additional_messages_then_should_throw
+            When_append_stream_with_expected_version_any_and_some_of_the_messages_previously_committed_and_with_additional_messages_then_should_throw
             ()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -333,9 +507,9 @@
         [Fact]
         public async Task When_append_stream_with_expected_version_and_duplicate_message_Id_then_should_throw()
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store
@@ -355,9 +529,9 @@
         [InlineData(ExpectedVersion.Any)]
         public async Task When_append_to_non_existent_stream_with_empty_collection_of_messages_then_should_create_empty_stream(int expectedVersion)
         {
-            using(var fixture = GetFixture())
+            using (var fixture = GetFixture())
             {
-                using(var store = await fixture.GetStreamStore())
+                using (var store = await fixture.GetStreamStore())
                 {
                     const string streamId = "stream-1";
                     await store.AppendToStream(streamId, expectedVersion, new NewStreamMessage[0]);


### PR DESCRIPTION
Added placeholder tests that verify the result of the append behavior and the future NextExpectedVersion. The tests involving `ExpectedVersion.Any` are broken for MsSql (but not in memory) because those do not return the actual `CurrentVersion`, but `-1` instead. I favored making copies of the idempotency tests instead of mutating them (something you may want to rollback due to test explosion).

OT: Also fixed a few typo's in test names.