### PR TITLE
Ability to read an empty stream backwards

### DIFF
--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
@@ -177,6 +177,36 @@
         }
 
         [Fact]
+        public async Task Can_read_empty_stream_backwards()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    await store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages());
+
+                    var page = await store.ReadStreamBackwards("stream-1", StreamVersion.End, 1);
+                    page.Status.ShouldBe(PageReadStatus.Success);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Can_read_empty_stream_forwards()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var store = await fixture.GetStreamStore())
+                {
+                    await store.AppendToStream("stream-1", ExpectedVersion.NoStream, CreateNewStreamMessages());
+
+                    var page = await store.ReadStreamForwards("stream-1", StreamVersion.Start, 1);
+                    page.Status.ShouldBe(PageReadStatus.Success);
+                }
+            }
+        }
+
+        [Fact]
         public async Task When_read_non_exist_stream_forwards_then_should_get_StreamNotFound()
         {
             using(var fixture = GetFixture())
@@ -273,7 +303,7 @@
         {
             var theories = new[]
             {
-               new ReadStreamTheory("stream-1", StreamVersion.End, 2,
+                new ReadStreamTheory("stream-1", StreamVersion.End, 2,
                     new ReadStreamPage("stream-1", PageReadStatus.Success, -1, 0, 2, ReadDirection.Backward, false,
                         new [] {
                           ExpectedStreamMessage("stream-1", 3, 2, SystemClock.GetUtcNow()),

--- a/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
+++ b/src/SqlStreamStore.AcceptanceTests/SqlStreamStoreAcceptanceTests.ReadStream.cs
@@ -187,6 +187,13 @@
 
                     var page = await store.ReadStreamBackwards("stream-1", StreamVersion.End, 1);
                     page.Status.ShouldBe(PageReadStatus.Success);
+                    page.Messages.Length.ShouldBe(0);
+                    page.FromStreamVersion.ShouldBe(StreamVersion.End);
+                    page.IsEnd.ShouldBeTrue();
+                    page.LastStreamVersion.ShouldBe(StreamVersion.End);
+                    page.NextStreamVersion.ShouldBe(StreamVersion.End);
+                    page.ReadDirection.ShouldBe(ReadDirection.Backward);
+                    page.StreamId.ShouldBe("stream-1");
                 }
             }
         }
@@ -202,6 +209,13 @@
 
                     var page = await store.ReadStreamForwards("stream-1", StreamVersion.Start, 1);
                     page.Status.ShouldBe(PageReadStatus.Success);
+                    page.Messages.Length.ShouldBe(0);
+                    page.FromStreamVersion.ShouldBe(StreamVersion.Start);
+                    page.IsEnd.ShouldBeTrue();
+                    page.LastStreamVersion.ShouldBe(StreamVersion.End);
+                    page.NextStreamVersion.ShouldBe(StreamVersion.Start);
+                    page.ReadDirection.ShouldBe(ReadDirection.Forward);
+                    page.StreamId.ShouldBe("stream-1");
                 }
             }
         }

--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -625,8 +625,12 @@ namespace SqlStreamStore
                     count--;
                 }
 
-                var lastStreamVersion = stream.Messages.Last().StreamVersion;
-                var nextStreamVersion = messages.Last().StreamVersion - 1;
+                var lastStreamVersion = stream.Messages.Count > 0 
+                    ? stream.Messages[stream.Messages.Count - 1].StreamVersion
+                    : StreamVersion.End;
+                var nextStreamVersion = messages.Count > 0 
+                    ? messages[messages.Count - 1].StreamVersion - 1 
+                    : StreamVersion.End;
                 var endOfStream = nextStreamVersion < 0;
 
                 var page = new ReadStreamPage(


### PR DESCRIPTION
... appears to be broken on the in memory implementation. This PR should fix that. Please review the values chosen to return upon reading an empty stream backwards (see tests). 