### PR TITLE
InMemoryStreamStore.ReadStreamBackward() Bug

### DIFF
--- a/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
+++ b/src/SqlStreamStore/InMemory/InMemoryStreamStore.cs
@@ -617,7 +617,6 @@ namespace SqlStreamStore
                             inMemorymessage.Type,
                             inMemorymessage.JsonMetadata,
                             ct =>  Task.Run(() => ReadMessageData(streamId, inMemorymessage.MessageId), ct));
-                        messages.Add(message);
                     }
                     messages.Add(message);
 


### PR DESCRIPTION
ReadStreamBackward without prefetch returns each message twice as part of reading a page. This PR fixes that behavior and adds tests that verify correct behavior for both reading forward and backward as a regression countermeasure.