### PR TITLE
Make PK non-clustered

### DIFF
--- a/src/SqlStreamStore.MsSql/MsSqlScripts/CreateSchema.sql
+++ b/src/SqlStreamStore.MsSql/MsSqlScripts/CreateSchema.sql
@@ -36,7 +36,7 @@ BEGIN
         [Type]              NVARCHAR(128)                           NOT NULL,
         JsonData            NVARCHAR(max)                           NOT NULL,
         JsonMetadata        NVARCHAR(max)                                   ,
-        CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (Position),
+        CONSTRAINT PK_Events PRIMARY KEY NONCLUSTERED (Position),
         CONSTRAINT FK_Events_Streams FOREIGN KEY (StreamIdInternal) REFERENCES dbo.Streams(IdInternal)
     );
 END


### PR DESCRIPTION
Should support more non-blocking writers, since inserts would not fall on the same page all the time. Maybe, should make the index with Id a clustered one...